### PR TITLE
sf: PhaseOffsets: Add missing low refresh rates

### DIFF
--- a/services/surfaceflinger/Scheduler/PhaseOffsets.cpp
+++ b/services/surfaceflinger/Scheduler/PhaseOffsets.cpp
@@ -97,6 +97,9 @@ PhaseOffsets::PhaseOffsets() {
                            highFpsLateAppOffsetNs};
 
     mOffsets.insert({RefreshRateType::POWER_SAVING, defaultOffsets});
+    mOffsets.insert({RefreshRateType::LOW0, defaultOffsets});
+    mOffsets.insert({RefreshRateType::LOW1, defaultOffsets});
+    mOffsets.insert({RefreshRateType::LOW2, defaultOffsets});
     mOffsets.insert({RefreshRateType::DEFAULT, defaultOffsets});
     mOffsets.insert({RefreshRateType::PERFORMANCE, highFpsOffsets});
 #ifdef QCOM_UM_FAMILY


### PR DESCRIPTION
Fixes "[SurfaceFlinger] Add vsync offset information to systrace."

* In the conflict resolution of the AOSP Q DPR1/QPR1 commit above,
  only higher refeesh rates were handled, leaving 60 to 57 cases broken.
  We did not realize this until now because no devices supported
  refresh rates below 60Hz.

Change-Id: Idbd774b8465d0b873db21f19cb9064317e2e0181
Signed-off-by: Jyotiraditya <jyotiraditya@aospa.co>